### PR TITLE
First merge on top of patch (#2)

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -162,8 +162,9 @@ LOCAL_CFLAGS       := -I../lib/angelscript/include      \
                       -DUSE_GLES2      \
                       -DHAVE_OGGVORBIS \
                       -DNDEBUG         \
-                      -DANDROID_PACKAGE_NAME=\"$(PACKAGE_NAME)\" \
-                      -DANDROID_APP_DIR_NAME=\"$(APP_DIR_NAME)\" \
+                      -DANDROID_PACKAGE_NAME=\"$(PACKAGE_NAME)\"    \
+                      -DANDROID_APP_DIR_NAME=\"$(APP_DIR_NAME)\"    \
+                      -DSUPERTUXKART_VERSION=\"$(PROJECT_VERSION)\" \
                       -std=gnu++0x
 
 LOCAL_STATIC_LIBRARIES := irrlicht bullet enet freetype ifaddrs angelscript  \

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.supertuxkart.stk_dbg"
           android:versionCode="1"
-          android:versionName="1.0"
+          android:versionName="git"
           android:installLocation="auto">
 
     <!-- This .apk has no Java code itself, so set hasCode to false. -->

--- a/android/README.ANDROID
+++ b/android/README.ANDROID
@@ -101,6 +101,14 @@ SDK_PATH        - Path to SDK directory
 
 NDK_PATH        - Path to NDK directory
 
+PROJECT_VERSION - Set Supertuxkart version number, for example "0.9.3" or 
+                  "git20170409" or whatever. 
+                  Default is: git.
+
+PROJECT_CODE    - Set Supertuxkart version code that is used in the manifest 
+                  file.
+                  Default is: 1.
+
 
 
 --------------------------------------------------------------------------------
@@ -110,29 +118,13 @@ NDK_PATH        - Path to NDK directory
 Making a release build is similar to typical compilation, but there are few
 additional things to do. 
 
-You have to change version numbers. This is important, because assets manager
-in STK checks these numbers and detects if already extracted data files are
+You have to set PROJECT_VERSION variable. This is important, because assets 
+manager in STK checks that value and detects if already extracted data files are
 up to date. So that when you will install new STK version, this will force new 
 data extraction automatically.
 
-So that you have to:
-
-1. Change "data/supertuxkart.git" to "data/supertuxkart.VERSION_NUMBER"
-
-2. Open "src/utils/constants.cpp" and change:
-
-    const char STK_VERSION[] = "git";
-      
-   to
-    
-    const char STK_VERSION[] = "VERSION_NUMBER";
-      
-   where "VERSION_NUMBER" is for example "0.9.3" or "git20170409" or whatever.
-    
-3. You can also update these lines in "android/AndroidManifest.xml":
-    android:versionCode="1"
-    android:versionName="1.0"
-
+The PROJECT_CODE variable typically should be set to a value higher than for
+previous release, so that users will receive the upgrade.
 
 Before compilation you have to set:
 

--- a/src/config/user_config.hpp
+++ b/src/config/user_config.hpp
@@ -451,6 +451,11 @@ namespace UserConfigParams
             PARAM_DEFAULT( BoolUserConfigParam(false, "screen_keyboard",
             &m_multitouch_group,
             "Enable screen keyboard.") );
+            
+    PARAM_PREFIX BoolUserConfigParam         m_hidpi_enabled
+            PARAM_DEFAULT( BoolUserConfigParam(false, "hidpi_enabled",
+            &m_multitouch_group,
+            "Enable high-DPI support.") );
 
     // ---- GP start order
     PARAM_PREFIX GroupUserConfigParam        m_gp_start_order

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -547,7 +547,8 @@ void cmdLineHelp()
                               "./data/stk_config.xml\n"
     "  -k,  --numkarts=NUM     Set number of karts on the racetrack.\n"
     "       --kart=NAME        Use kart NAME.\n"
-    "       --ai=a,b,...       Use the karts a, b, ... for the AI.\n"
+    "       --ai=a,b,...       Use the karts a, b, ... for the AI, and additional player kart.\n"
+    "       --aiNP=a,b,...     Use the karts a, b, ... for the AI, no additional player kart.\n"
     "       --laps=N           Define number of laps to N.\n"
     "       --mode=N           N=1 Beginner, N=2 Intermediate, N=3 Expert, N=4 SuperTux.\n"
     "       --type=N           N=0 Normal, N=1 Time trial, N=2 Follow The Leader\n"
@@ -1106,6 +1107,13 @@ int handleCmdLine()
         // Add 1 for the player kart
         race_manager->setNumKarts((int)l.size()+1);
     }   // --ai
+
+    if(CommandLine::has("--aiNP", &s))
+    {
+        const std::vector<std::string> l=StringUtils::split(std::string(s),',');
+        race_manager->setDefaultAIKartList(l);
+        race_manager->setNumKarts((int)l.size());
+    }   // --aiNP
 
     if(CommandLine::has( "--mode", &s) || CommandLine::has( "--difficulty", &s))
     {

--- a/src/race/race_manager.cpp
+++ b/src/race/race_manager.cpp
@@ -281,7 +281,9 @@ void RaceManager::computeRandomKartList()
     }
 
     m_ai_kart_list.clear();
-    unsigned int m = std::min( (unsigned) n,  (unsigned)m_default_ai_list.size());
+
+    //Use the command line options AI list.
+    unsigned int m = std::min( (unsigned) m_num_karts,  (unsigned)m_default_ai_list.size());
 
     for(unsigned int i=0; i<m; i++)
     {

--- a/src/states_screens/race_result_gui.cpp
+++ b/src/states_screens/race_result_gui.cpp
@@ -380,17 +380,25 @@ void RaceResultGUI::eventCallback(GUIEngine::Widget* widget,
         return;
     }
 
-    // This is a normal race, nothing was unlocked
-    // -------------------------------------------
     StateManager::get()->popMenu();
     if (name == "top")                 // Setup new race
     {
         race_manager->exitRace();
         race_manager->setAIKartOverride("");
-        Screen* newStack[] = { MainMenuScreen::getInstance(),
-                              RaceSetupScreen::getInstance(),
-                              NULL };
-        StateManager::get()->resetAndSetStack(newStack);
+
+        //If pressing continue quickly in a losing challenge
+        if (race_manager->raceWasStartedFromOverworld())
+        {
+            StateManager::get()->resetAndGoToScreen(MainMenuScreen::getInstance());
+            OverWorld::enterOverWorld();
+        }
+        else
+        {
+            Screen* newStack[] = { MainMenuScreen::getInstance(),
+                                  RaceSetupScreen::getInstance(),
+                                  NULL };
+            StateManager::get()->resetAndSetStack(newStack);
+        }
     }
     else if (name == "middle")        // Restart
     {

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -246,7 +246,12 @@ LightNode* findNearestLight()
 
 bool handleContextMenuAction(s32 cmd_id)
 {
-    unsigned int kart_num = Camera::getActiveCamera()->getKart()->getWorldKartId();
+    Camera* camera = Camera::getActiveCamera();
+    unsigned int kart_num = 0;
+    if (camera != NULL && camera->getKart() != NULL)
+    {
+        kart_num = camera->getKart()->getWorldKartId();
+    }
 
     World *world = World::getWorld();
     Physics *physics = Physics::getInstance();


### PR DESCRIPTION
* Reduce number of places version number needs to be changed on release

* FIx #3167 attempt

* Improve 3167 patch

* Improve 3167 patch

* Improve 3167 patch

* Mitigate AI-related edge cases of original fx

* Fixed compilation in debug mode.

* Some improvements for touch device

* Fixed minor bug in touch settings dialog

* Cleanup input.xml file (remove unused properties in some cases), add a little inline doc to make it a little easier to customize

* Update translations

* Keep acceleration sensitivity for up/down button when accelerometer is enabled

* Improved speedometer and nitrometer (#3177)

* New speedometer and nitrometer gui

* Update Speedometer and Nitrometer

* Improve nitro background

* Improve nitro bar drawing

* Improved meters

* Improve meter and rank drawing

* Agressive smoothing and higher visibility

* Helper function for meter drawing

* Helper function for meter drawing

* Improved meters

* New nitro bar, slight 3D effects and hopefully fix compilation

* Update license

* Tweak nitro meter in android race gui

* Allow to use bigger fonts on desktop version for easier debugging

* Use 4 32bit floats for quaternion for sam's wall

* Use 2 digits for shader order

* Remove unneeded skinned mesh version for tilling and vertical mapping shader

* Fix billboard text

* Update tool for new sstreaming characteristics

* Update for new sstreaming characteristics

* Update for new sstreaming characteristics

* Update for new sstreaming characteristics

* Update for new sstreaming characteristics

* Update for new sstreaming characteristics

* New setQuad function

Allows to easily update the coordinates of a quad (used for dynamic slipstreaming quad)

* New setQuad function

* Remember previous positions

* Remember previous positions

Use an array of 30 Vec3 to remember the previous kart positions 0,25s before. Each one is updated with the previous one, starting from the oldest.

time_previous_counter is used to keep the time of the oldest as close as possible to 0,25s ; in case the physics ticks proceed faster or slower than 1/120th of second.

* Remember previous positions

* Allow instantSpeedIncrease use from Kart

* Allow instantSpeedIncrease use from Kart

* Allow instantSpeedIncrease use from Kart

* Completely revamps slipstreaming

* Update header for slipstreaming improvements

* Slipstreaming characteristics completely reworked

* Fixes a too small index

* Checks to avoid undefined operations on moving textures

* Remove erroneous chars at EOF

* Minor tweak for init android dialog

* Go back to the overworld in losing challenges (#3192)

* Update README.md (#3181)

* Update README.md

- Add recompilation instructions
- Add build threading instructions
- Rearranged 1 sentence with passive voice to match the rest of the readme

* Update README.md

* Update README.md

Clarification

* Update README.md

Rephrasing, reformatting

* Nitro fixes (#3190)

* Nitro fixes

* Remove the attachment of a kart on elimination

* Improved AI testing (#3184)

* New command line option for testing

* Fix command line option

* Allow races from command line without player kart

* Use the new command line option for testing

Also increase the default number of karts for testing from 9 (including player kart) to 15 (no player kart) for reduced randomness.
And set the default test difficulty to SuperTux

* Fix member variable name

* Fix member variable name

* Add shader specialized for roads, still some stuff to be tuned

* minor Update README.md

Refine syntax to match protocol
moved one line back into code fence.

* Avoid a crash in general text field dialog.

onEnterPressed can be executed twice - in event handler and in input manager.

* Reduce speedometer images to a more reasonable size

* Ajust forgotten texture

* At general request, remove follow-the-lreader from story mode

* Attempt to fix #3195

* Better gauge goal

* Various improvements

1)Use a new helper function for the drawing as the code was nearly identical at three different places
2)Fixes the coloring of transparent points : full color as intended, rather than black
3)Additional drawing points to properly manage the gauge_goal going outside of the gauge_full space

* New helper function for drawing meters

* Fixes speedometer saturation

* Better GP points distribution (#3178)

* Fixes server_only build issue (#3199)

* Fixed a bug in generate_assets script

* Keep the camera looking to the same kart when changing view type (#3205)

Except for first-person view which keeps resetting to the player kart (the FP view itself is linked to it)

* Various slipstreaming refinements (#3202)

* New getRecentPreviousXYZ function

* New getRecentPreviousXYZ function

* New getRecentPreviousXYZ function

* General slipstreaming refinements

* Increase the minimum time to get the slipstream bonus

The obsolete parameter is not yet removed as several other files would have to be changed to not trigger an error.

* Slipstreaming characteristics update

* Changed slipstreaming characteristics

* Update slipstreaming characteristics

* Update slipstreaming characteristics

* Update slipstreaming characteristics

* Update slipstreaming characteristics

* Update slipstreaming characteristics

* Remove slipstreaming power engine bonus per kart type

Power engine bonus is already balanced by the different weights : a heavier kart needs more engine power to achieve/maintain the same speed.

* Remove an unused function

* Various slipstreaming refinements

* Pull the XYZ history size from config

* Pull the XYZ history size from config

* Remove unnecessary logs

* Fix a frenchism with fix

* Update android project after recent modifications related to STK project version

* Bugfix

* Simplify setting android project version